### PR TITLE
proxy with nginx in docker

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+---
+web:
+  image: nginx:1.21
+  ports:
+    - "1234:1234"
+  volumes:
+    - ./ld-proxy.conf:/etc/nginx/conf.d/default.conf:ro
+    - ./dist:/srv/www:ro
+  

--- a/index.js
+++ b/index.js
@@ -1,14 +1,18 @@
+// the sdk wants this
+window.setImmediate = (fn) => setTimeout(fn,0)
 const LaunchDarkly = require('launchdarkly-node-server-sdk');
-const sdk_key = ""; // remember, it's SDK key, NOT client ID
-const client = LaunchDarkly.init(sdk_key);
+const sdk_key = process.env.LD_SDK_KEY; // remember, it's SDK key, NOT client ID
+const client = LaunchDarkly.init(sdk_key, {
+  streamUri: "http://localhost:1234/proxy/stream/",
+  baseUri: "http://localhost:1234/proxy/app/",
+  eventsUri: "http://localhost:1234/proxy/events/"
+});
 
 client.once("ready", () => {
-    client.variation("pricing-tier-3", {"key": "user@test.com"}, false,
-      (err, showFeature) => {
-        if (showFeature) {
-          console.log("Flag is true!");
-        } else {
-          console.log("Flag is false!");
-        }
-      });
+    client.allFlagsState({"key": "user@test.com"})
+      .then(
+          (flags) => console.log(flags.toJSON()),
+          (e) => console.error(e)
+       )
+    
 });

--- a/ld-proxy.conf
+++ b/ld-proxy.conf
@@ -1,0 +1,33 @@
+server {
+        listen 1234 default_server;
+        listen [::]:1234 default_server;
+
+        root /srv/www;
+        index index.html;
+
+        server_name localhost;
+        location /proxy/events/ {
+            proxy_set_header Host events.launchdarkly.com;
+            proxy_pass https://events.launchdarkly.com/;
+            proxy_redirect https://events.launchdarkly.com/ http://$host/;
+        }
+
+        location /proxy/app/ {
+            proxy_set_header Host app.launchdarkly.com;
+            proxy_pass https://app.launchdarkly.com/;
+            proxy_redirect https://app.launchdarkly.com/ http://$host/;
+        }
+
+        location /proxy/stream/ {
+            proxy_set_header Host stream.launchdarkly.com;
+            proxy_buffering off;
+            proxy_cache off;
+            proxy_set_header Connection '';
+            proxy_http_version 1.1;
+            chunked_transfer_encoding off;
+            
+            proxy_pass https://stream.launchdarkly.com/;
+            proxy_redirect https://stream.launchdarkly.com/ http://$host/;
+        }
+
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "scripts": {
-    "start": "parcel index.html"
+    "start": "parcel index.html",
+    "build": "parcel build index.html"
   },
   "dependencies": {
     "launchdarkly-node-server-sdk": "^6.2.0"


### PR DESCRIPTION
- Quick and dirty polyfill for `setImmediate`
- Use nginx to proxy the stream/base/events URI to LaunchDarkly SaaS

Works for me 
