### PR TITLE
fix up monkey patches for new version of event source

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,10 @@
 ---
-web:
-  image: nginx:1.21
-  ports:
-    - "1234:1234"
-  volumes:
-    - ./ld-proxy.conf:/etc/nginx/conf.d/default.conf:ro
-    - ./dist:/srv/www:ro
-  
+services:
+  web:
+    image: nginx:1.21
+    ports:
+      - "1234:1234"
+    volumes:
+      - ./ld-proxy.conf:/etc/nginx/conf.d/default.conf:ro
+      - ./dist:/srv/www:ro
+    

--- a/index.html
+++ b/index.html
@@ -1,5 +1,8 @@
 <html>
 <body>
+	<p>Check the dev console for logs</p>
+	<pre id="output"></pre>
   <script src="./index.js"></script>
+  
 </body>
 </html>

--- a/index.js
+++ b/index.js
@@ -1,13 +1,34 @@
 // the sdk wants this
 window.setImmediate = (fn) => setTimeout(fn,0)
+
+// fix the http/https polyfill
+const https = require('https')
+const http = require('http')
+const url = require('url')
+
+function wrapHTTPRequestFn(fn) {
+  return function wrappedRequest(a,b,c) {
+     if (arguments.length == 3) {
+      return fn(Object.assign({}, b, url.parse(a)), c)  
+    }
+    return fn(a,b)
+  }
+}
+https.request = wrapHTTPRequestFn(https.request)
+http.request = wrapHTTPRequestFn(http.request)
+
 const LaunchDarkly = require('launchdarkly-node-server-sdk');
 const sdk_key = process.env.LD_SDK_KEY; // remember, it's SDK key, NOT client ID
 const client = LaunchDarkly.init(sdk_key, {
-  streamUri: "http://localhost:1234/proxy/stream/",
-  baseUri: "http://localhost:1234/proxy/app/",
-  eventsUri: "http://localhost:1234/proxy/events/"
+  streamUri: "/proxy/stream/",
+  baseUri: "/proxy/app/",
+  eventsUri: "/proxy/events/"
 });
-
+client.on("update", function() {
+    client.allFlagsState({"key": "user@test.com"}).then(function(flags) {
+	    document.getElementById("output").innerText = JSON.stringify(flags.toJSON(), null, 2)
+    })
+})
 client.once("ready", () => {
     client.allFlagsState({"key": "user@test.com"})
       .then(

--- a/ld-proxy.conf
+++ b/ld-proxy.conf
@@ -25,7 +25,7 @@ server {
             proxy_set_header Connection '';
             proxy_http_version 1.1;
             chunked_transfer_encoding off;
-            
+            proxy_read_timeout 300s; 
             proxy_pass https://stream.launchdarkly.com/;
             proxy_redirect https://stream.launchdarkly.com/ http://$host/;
         }


### PR DESCRIPTION
- Fix up docker compose so it works with podman-compose (forgot the services key)
- Added display of all flags when the rules update 
- Monkey-patch to workaround this issue: https://github.com/substack/https-browserify/issues/9